### PR TITLE
Fix: Resolve 'Val cannot be reassigned' in build.gradle.kts

### DIFF
--- a/TorboxProvider/build.gradle.kts
+++ b/TorboxProvider/build.gradle.kts
@@ -12,7 +12,6 @@ version = 1
 
 cloudstream {
     // All of these properties are optional, you can safely remove any of them.
-    name = "Torbox" // Added name property
     description = "Integrates with Torbox.app debrid service" // Updated description
     authors = listOf("YourName") // Update author
 


### PR DESCRIPTION
Removed the explicit assignment to `name` in the `cloudstream` block of `TorboxProvider/build.gradle.kts`.

The plugin name is typically derived from the module name or other configuration, and attempting to set it directly was causing a build failure due to reassigning an immutable property (val).

This change allows the Gradle script to be parsed correctly, resolving the reported build error. Further build issues related to Android SDK configuration are separate from this specific fix.