### PR TITLE
Fix: Resolve TorboxProvider build errors and update dependencies

### DIFF
--- a/TorboxProvider/build.gradle.kts
+++ b/TorboxProvider/build.gradle.kts
@@ -5,6 +5,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.0") // Or other version
     // implementation("io.ktor:ktor-client-core:2.3.5") // Example, if not using app.get
     // implementation("io.ktor:ktor-client-cio:2.3.5") // Example
+    implementation("androidx.preference:preference-ktx:1.2.1") // Added for PreferenceFragmentCompat
 }
 
 // Use an integer for version numbers

--- a/TorboxProvider/src/main/kotlin/com/torbox/SettingsFragment.kt
+++ b/TorboxProvider/src/main/kotlin/com/torbox/SettingsFragment.kt
@@ -1,0 +1,30 @@
+package com.torbox
+
+import android.os.Bundle
+import androidx.preference.PreferenceFragmentCompat
+
+class SettingsFragment : PreferenceFragmentCompat() {
+
+    companion object {
+        const val PREFS_FILE = "TorboxPrefs"
+        const val TORBOX_API_KEY = "torbox_api_key"
+    }
+
+    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+        setPreferencesFromResource(R.xml.torbox_preferences, rootKey) // Placeholder, actual XML might be different or not used if UI is fully dynamic
+
+        // Example: Find preference and set summary or listener
+        // val apiKeyPreference = findPreference<EditTextPreference>(TORBOX_API_KEY)
+        // apiKeyPreference?.setOnPreferenceChangeListener { preference, newValue ->
+        //     // Handle API key change
+        //     true
+        // }
+    }
+}
+
+// Minimal R.xml.torbox_preferences if needed by setPreferencesFromResource
+// This would typically be in res/xml/torbox_preferences.xml
+// For now, just defining the class. If R.xml.torbox_preferences is strictly needed at compile time
+// and not provided by the Cloudstream environment, this might need a placeholder XML.
+// However, many plugins manage settings UI without a static XML if they use custom views.
+// The getApiKey() method just needs the constants, not necessarily a full preference screen.

--- a/TorboxProvider/src/main/res/layout/settings_fragment.xml
+++ b/TorboxProvider/src/main/res/layout/settings_fragment.xml
@@ -26,23 +26,21 @@
         android:orientation="horizontal"
         android:layout_marginTop="16dp">
 
-        <Button
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/resetButton"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:text="Reset"
-            android:layout_marginEnd="8dp"
-            style="?attr/buttonBarNegativeButtonStyle"/>
+            android:layout_marginEnd="8dp" />
 
-        <Button
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/addButton"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:text="Save"
-            android:layout_marginStart="8dp"
-            style="?attr/buttonBarPositiveButtonStyle"/>
+            android:layout_marginStart="8dp" />
     </LinearLayout>
 
 </LinearLayout>

--- a/TorboxProvider/src/main/res/xml/torbox_preferences.xml
+++ b/TorboxProvider/src/main/res/xml/torbox_preferences.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <EditTextPreference
+        android:key="torbox_api_key"
+        android:title="Torbox API Key"/>
+</PreferenceScreen>


### PR DESCRIPTION
This commit addresses several build failures in the TorboxProvider plugin:

1.  Corrected XML button styling in `settings_fragment.xml` by using MaterialButton and default Material styles.
2.  Created `SettingsFragment.kt` and a basic `torbox_preferences.xml` to resolve missing class and resource issues. Added `androidx.preference:preference-ktx` dependency.
3.  Resolved Kotlin compilation errors in `TorboxProvider.kt`:
    - Updated `newTorrentLoadResponse` calls to pass `TvType.Torrent.name` (String) instead of the enum.
    - Ensured `newExtractorLink` is used as per deprecation warnings, simplifying its usage to `(source, name, url)` as other parameters caused conflicts with the available API stubs. Omitted `referer`, `quality`, and `isM3u8` from this call.
    - Commented out assignments to `size`, `seeds`, and `peers` on `TorrentSearchResponse` and `TorrentLoadResponse` as these were causing 'Unresolved reference' errors, likely due to restrictive or incomplete API stubs in the build environment. TODO comments have been added to denote these areas.

The plugin now compiles successfully. The commented-out code and simplified ExtractorLink may result in some missing metadata or functionality at runtime but allow the plugin to build.